### PR TITLE
Add blocking timeout to automatically clear manual overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Room Light Control is a Home Assistant integration designed to automatically con
 - **Manual Interference Handling**: Automatically pauses auto-control if manual actions are detected, WHEN
   -  ... lights are already on
   -  ... a scene is activated while auto-control is running (e.g. Philips Hue Scene turned on with your Smartphone)
+- **Automatic Blocking Timeout**: Optionally configure how long manual overrides or blocking entities can hold control before
+  Room Light Control turns the lights off and resumes automation.
 - **Turn-Off Blocking Entities**: Configure entities that, when active, prevent the lights from being turned off (e.g., if a specific device is running or a condition is met).
 - **Flexible Configuration for Advanced Users**: Advanced users can define custom scripts or scenes for more tailored lighting behaviors, while simple setups can rely on automatic light discovery and control.
 
@@ -61,6 +63,7 @@ room_light_control:
 | `turn_off_delay` | The time delay (in seconds) before turning off the lights after no motion is detected. Acts also as a timeout for the turn_off_sensor, if it is configured. (Optional) | `180` |
 | `turn_off_sensor` | A sensor used to detect when a person has left the room. When the state changes from on to off, the lights will be turned off. (Optional) |  |
 | `turn_off_blocking_entity` | An entity that, when active, prevents the lights from turning off. (Optional) |  |
+| `blocking_entities_timeout` | Automatically clear manual overrides or blocking entities after the specified number of seconds with no motion. Set to `0` to disable the timeout. (Optional) | Matches `turn_off_delay` (`180` by default) |
 
 **Example Configurations:**
 
@@ -112,12 +115,23 @@ e) **Using a Human Presence Sensor (Aqara FP1)** - The lights will turn on when 
 ```yaml
 - bath_light_control:
     room: bath
-    motion_sensor: 
+    motion_sensor:
       - binary_sensor.bath_ground_motion_sensor # PIR motion sensor
       - binary_sensor.bath_occupancy # mmwave motion sensor
     turn_off_sensor:
       - binary_sensor.bath_occupancy # mmwave motion sensor
-    activate_light_script_or_scene: script.bath_activate_light 
+    activate_light_script_or_scene: script.bath_activate_light
+```
+
+f) **Automatic Timeout for Manual Overrides** - When lights are turned on manually or blocked by an entity, Room Light Control will resume automation after no motion is detected for the configured timeout. Setting the timeout to `0` disables the auto-clear behavior.
+```yaml
+- hobby_room_light_control:
+    room: hobby_room
+    motion_sensor:
+      - binary_sensor.hobby_room_motion
+    turn_off_blocking_entity:
+      - input_boolean.hobby_room_manual_hold
+    blocking_entities_timeout: 600  # 10 minutes after motion stops
 ```
 
 ## Debugging
@@ -153,6 +167,7 @@ logger:
 **New Features**
 - Renamed `turn_on_light` to `activate_light_script_or_scene` to better reflect its intended purpose of only working with scenes or scripts.
 - Made `activate_light_script_or_scene` an optional configuration variable. When it is not provided, the integration will automatically turn on lights in the room (`roomLightEntities`) instead of requiring a scene or script.
+- Added `blocking_entities_timeout` to automatically clear manual overrides and resume automation after inactivity.
 
 **Bug Fixes**
 - Improved logging to clearly indicate whether `roomLightEntities` are being used by default or if a scene/script is being activated.

--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ Room Light Control is a Home Assistant integration designed to automatically con
 - **Manual Interference Handling**: Automatically pauses auto-control if manual actions are detected, WHEN
   -  ... lights are already on
   -  ... a scene is activated while auto-control is running (e.g. Philips Hue Scene turned on with your Smartphone)
-- **Automatic Blocking Timeout**: Optionally configure how long manual overrides or blocking entities can hold control before
-  Room Light Control turns the lights off and resumes automation.
+- **Automatic Blocking Timeout**: Optionally configure how long manual overrides or blocking entities can hold control before Room Light Control turns the lights off and resumes automation. Defaults to 3 hours of inactivity.
 - **Turn-Off Blocking Entities**: Configure entities that, when active, prevent the lights from being turned off (e.g., if a specific device is running or a condition is met).
 - **Flexible Configuration for Advanced Users**: Advanced users can define custom scripts or scenes for more tailored lighting behaviors, while simple setups can rely on automatic light discovery and control.
 
@@ -63,7 +62,7 @@ room_light_control:
 | `turn_off_delay` | The time delay (in seconds) before turning off the lights after no motion is detected. Acts also as a timeout for the turn_off_sensor, if it is configured. (Optional) | `180` |
 | `turn_off_sensor` | A sensor used to detect when a person has left the room. When the state changes from on to off, the lights will be turned off. (Optional) |  |
 | `turn_off_blocking_entity` | An entity that, when active, prevents the lights from turning off. (Optional) |  |
-| `blocking_entities_timeout` | Automatically clear manual overrides or blocking entities after the specified number of seconds with no motion. Set to `0` to disable the timeout. (Optional) | Matches `turn_off_delay` (`180` by default) |
+| `blocking_entities_timeout` | Automatically clear manual overrides or blocking entities after the specified number of seconds with no motion. Set to `0` to disable the timeout. (Optional) | `10800` (3 hours) |
 
 **Example Configurations:**
 
@@ -123,7 +122,7 @@ e) **Using a Human Presence Sensor (Aqara FP1)** - The lights will turn on when 
     activate_light_script_or_scene: script.bath_activate_light
 ```
 
-f) **Automatic Timeout for Manual Overrides** - When lights are turned on manually or blocked by an entity, Room Light Control will resume automation after no motion is detected for the configured timeout. Setting the timeout to `0` disables the auto-clear behavior.
+f) **Automatic Timeout for Manual Overrides** - When lights are turned on manually or blocked by an entity, Room Light Control will resume automation after no motion is detected for the configured timeout. If omitted, the timeout defaults to 3 hours. Setting the timeout to `0` disables the auto-clear behavior.
 ```yaml
 - hobby_room_light_control:
     room: hobby_room
@@ -167,7 +166,7 @@ logger:
 **New Features**
 - Renamed `turn_on_light` to `activate_light_script_or_scene` to better reflect its intended purpose of only working with scenes or scripts.
 - Made `activate_light_script_or_scene` an optional configuration variable. When it is not provided, the integration will automatically turn on lights in the room (`roomLightEntities`) instead of requiring a scene or script.
-- Added `blocking_entities_timeout` to automatically clear manual overrides and resume automation after inactivity.
+- Added `blocking_entities_timeout` to automatically clear manual overrides and resume automation after inactivity, defaulting to 3 hours when not configured.
 
 **Bug Fixes**
 - Improved logging to clearly indicate whether `roomLightEntities` are being used by default or if a scene/script is being activated.

--- a/custom_components/room_light_control/__init__.py
+++ b/custom_components/room_light_control/__init__.py
@@ -56,6 +56,7 @@ from .const import (
     STATES,
 
     DEFAULT_DELAY,
+    DEFAULT_BLOCKING_TIMEOUT,
     DEFAULT_ILLUMINANCE_THRESHOLD,
     ACTIVATE_LIGHT_SCRIPT_OR_SCENE,
     CONF_TURN_OFF_LIGHT,
@@ -92,7 +93,7 @@ ENTITY_SCHEMA = vol.Schema(
         vol.Required(CONF_ROOM, default=[]): cv.entity_ids,
         vol.Required(CONF_ROOMS, default=[]): cv.entity_ids,
         vol.Optional(CONF_TURN_OFF_DELAY, default=DEFAULT_DELAY): cv.positive_int,
-        vol.Optional(CONF_BLOCKED_TIMEOUT, default=DEFAULT_DELAY): cv.positive_int,
+        vol.Optional(CONF_BLOCKED_TIMEOUT, default=DEFAULT_BLOCKING_TIMEOUT): cv.positive_int,
         vol.Optional(CONF_MOTION_SENSOR_RESETS_TIMER, default=False): cv.boolean,
         vol.Required(CONF_MOTION_SENSOR, default=[]): cv.entity_ids,
         vol.Required(CONF_MOTION_SENSORS, default=[]): cv.entity_ids,
@@ -1024,7 +1025,7 @@ class Model:
         self.turnOffDelay = config.get(CONF_TURN_OFF_DELAY, DEFAULT_DELAY)
 
     def config_blocked_timeout(self, config):
-        self.blockedTimeout = config.get(CONF_BLOCKED_TIMEOUT, self.turnOffDelay)
+        self.blockedTimeout = config.get(CONF_BLOCKED_TIMEOUT, DEFAULT_BLOCKING_TIMEOUT)
         self.update(blocking_entities_timeout=self.blockedTimeout)
 
     def config_other(self, config):

--- a/custom_components/room_light_control/__init__.py
+++ b/custom_components/room_light_control/__init__.py
@@ -68,6 +68,7 @@ from .const import (
     CONF_ILLUMINANCE_SENSOR_THRESHOLD,
     CONF_TURN_OFF_BLOCKING_ENTITY,
     CONF_TURN_OFF_BLOCKING_ENTITIES,
+    CONF_BLOCKED_TIMEOUT,
     CONF_TURN_OFF_DELAY,
     CONF_MOTION_SENSOR_RESETS_TIMER,
 
@@ -91,6 +92,7 @@ ENTITY_SCHEMA = vol.Schema(
         vol.Required(CONF_ROOM, default=[]): cv.entity_ids,
         vol.Required(CONF_ROOMS, default=[]): cv.entity_ids,
         vol.Optional(CONF_TURN_OFF_DELAY, default=DEFAULT_DELAY): cv.positive_int,
+        vol.Optional(CONF_BLOCKED_TIMEOUT, default=DEFAULT_DELAY): cv.positive_int,
         vol.Optional(CONF_MOTION_SENSOR_RESETS_TIMER, default=False): cv.boolean,
         vol.Required(CONF_MOTION_SENSOR, default=[]): cv.entity_ids,
         vol.Required(CONF_MOTION_SENSORS, default=[]): cv.entity_ids,
@@ -317,6 +319,7 @@ class RoomLightController(entity.Entity):
             CONF_ILLUMINANCE_SENSOR,
             CONF_ILLUMINANCE_SENSOR_THRESHOLD,
             CONF_TURN_OFF_DELAY,
+            "blocking_entities_timeout",
         ]
         for k, v in self.attributes.items():
             if k in PERSISTED_STATE_ATTRIBUTES:
@@ -335,6 +338,8 @@ class RoomLightController(entity.Entity):
 
     def set_attr(self, k, v):
         if k == CONF_TURN_OFF_DELAY:
+            v = str(v) + "s"
+        elif k == "blocking_entities_timeout" and v is not None:
             v = str(v) + "s"
         self.attributes[k] = v
 
@@ -367,9 +372,11 @@ class Model:
         self.illuminanceSensorEntity = None
         self.illuminanceSensorThreshold = None
         self.turnOffDelay = None
+        self.blockedTimeout = None
         self.turnOffScript = []
         self.activateLightSceneOrScript = []
         self.timer_handle = None
+        self.blocking_timer_handle = None
         self.name = None
         self.log = logging.getLogger(__name__ + "." + config.get(CONF_NAME))
         self.context = None
@@ -392,6 +399,7 @@ class Model:
         self.config_turn_off_script(config)
         self.config_turn_on_scene(config)
         self.config_turn_off_delay(config)
+        self.config_blocked_timeout(config)
         self.config_other(config)
         self.prepare_service_data()
 
@@ -445,8 +453,12 @@ class Model:
                 self.log.debug("motion_sensor_state_change :: CONF_MOTION_SENSOR_RESETS_TIMER")
                 self.update(notes="The sensor turned off and reset the timeout. Timer started.")
                 self._reset_timer()
-            else: 
-                self.motion_sensor_off()              
+            else:
+                self.motion_sensor_off()
+
+        if self.matches(new.state, self.SENSOR_OFF_STATE) and self.is_blocked():
+            self.log.debug("motion_sensor_state_change :: motion sensor turned off while blocked")
+            self._schedule_blocking_timer()
 
     @callback
     def turn_off_sensor_state_change(self, entity, old, new):
@@ -603,11 +615,70 @@ class Model:
             self.update(expires_at="waiting for motion sensor off event")
         else:
             self.log.debug("timer_expire :: Trigger timer_expires event")
-            
+
             if self.is_turn_off_sensor_off():
                 self.log.debug("Turn_off_sensor timeout reached")
 
-            self.timer_expires()            
+            self.timer_expires()
+
+    def _cancel_blocking_timer(self):
+        if self.blocking_timer_handle is None:
+            return
+
+        if self.blocking_timer_handle.is_alive():
+            self.blocking_timer_handle.cancel()
+
+        self.blocking_timer_handle = None
+
+    def _schedule_blocking_timer(self):
+        if self.blockedTimeout is None:
+            return
+
+        if self.blockedTimeout <= 0:
+            self.update(blocking_expires_at=None)
+            return
+
+        if self.is_motion_sensor_on():
+            self.log.debug("Blocking timer waiting for motion sensor to turn off.")
+            self._cancel_blocking_timer()
+            self.update(blocking_expires_at=None)
+            return
+
+        self._cancel_blocking_timer()
+
+        expiry_time = datetime.now() + timedelta(seconds=self.blockedTimeout)
+        self.log.info("Starting blocking timeout for %ss", str(self.blockedTimeout))
+
+        self.blocking_timer_handle = Timer(self.blockedTimeout, self._blocking_timer_expired)
+        self.blocking_timer_handle.start()
+
+        if self.is_turn_off_blocked():
+            self.log.debug("Blocking timer scheduled but turn off is currently blocked.")
+
+        self.update(blocking_expires_at=expiry_time)
+
+    def _blocking_timer_expired(self):
+        self.log.debug("Blocking timer expired")
+
+        self.blocking_timer_handle = None
+
+        if not self.is_blocked():
+            self.log.debug("Ignoring blocking timer expiration because state is no longer blocked.")
+            return
+
+        if self.is_turn_off_blocked():
+            self.log.debug("Turn off still blocked; rescheduling blocking timer.")
+            self._schedule_blocking_timer()
+            return
+
+        if self.is_motion_sensor_on():
+            self.log.debug("Motion detected again; rescheduling blocking timer.")
+            self._schedule_blocking_timer()
+            return
+
+        self.log.info("Blocking timeout reached; turning off room lights.")
+        self.update(blocking_expires_at=datetime.now())
+        self.turnOffLightEntities()
 
     # =====================================================
     # S T A T E   M A C H I N E   C O N D I T I O N S
@@ -805,9 +876,12 @@ class Model:
             self.update(blocked_by=self._turn_off_blocking_entity_state())
         else:
             self.update(blocked_by=self._state_entity_state())
+        self._schedule_blocking_timer()
 
     def on_exit_blocked(self):
         self.log.debug("Exiting blocked")
+        self._cancel_blocking_timer()
+        self.update(blocking_expires_at=None)
 
     # =====================================================
     #    C O N F I G U R A T I O N  &  V A L I D A T I O N
@@ -949,6 +1023,10 @@ class Model:
     def config_turn_off_delay(self, config):
         self.turnOffDelay = config.get(CONF_TURN_OFF_DELAY, DEFAULT_DELAY)
 
+    def config_blocked_timeout(self, config):
+        self.blockedTimeout = config.get(CONF_BLOCKED_TIMEOUT, self.turnOffDelay)
+        self.update(blocking_entities_timeout=self.blockedTimeout)
+
     def config_other(self, config):
         self.ignore_state_changes_until = datetime.now()
 
@@ -1013,9 +1091,9 @@ class Model:
         if service_data is not None:
             params = service_data
 
-        params["entity_id"] = entity        
+        params["entity_id"] = entity
         self.hass.add_job(
-            self.hass.services.async_call(domain, service, service_data, context=self.context)
+            self.hass.services.async_call(domain, service, params, context=self.context)
         )
 
     def set_context(self, parent: Optional[Context] = None) -> None:
@@ -1072,6 +1150,7 @@ class Model:
         self.log.debug("Illuminance Sensor Threshold    %s", str(self.illuminanceSensorThreshold))
         self.log.debug("Turn On - Scene or Script:      %s", str(self.activateLightSceneOrScript))
         self.log.debug("Turn Off - Script:              %s", str(self.turnOffScript))
-        self.log.debug("Turn Off - Blocking Entities    %s", str(self.turnOffBlockingEntities))        
+        self.log.debug("Turn Off - Blocking Entities    %s", str(self.turnOffBlockingEntities))
+        self.log.debug("Turn Off - Blocking Timeout     %s", str(self.blockedTimeout))
         self.log.debug("Turn Off - Delay:               %s", str(self.turnOffDelay))
         self.log.debug("--------------------------------------------------")

--- a/custom_components/room_light_control/const.py
+++ b/custom_components/room_light_control/const.py
@@ -18,6 +18,7 @@ CONF_ILLUMINANCE_SENSOR_THRESHOLD = "illuminance_sensor_threshold"
 DEFAULT_ILLUMINANCE_THRESHOLD = 5.0
 
 DEFAULT_DELAY = 180
+DEFAULT_BLOCKING_TIMEOUT = 3 * 60 * 60  # 3 hours
 
 # activate_light_script_or_scene (either script or scene)
 ACTIVATE_LIGHT_SCRIPT_OR_SCENE = "activate_light_script_or_scene"

--- a/custom_components/room_light_control/const.py
+++ b/custom_components/room_light_control/const.py
@@ -28,6 +28,7 @@ CONF_TURN_OFF_DELAY = "turn_off_delay"
 
 CONF_TURN_OFF_BLOCKING_ENTITY = "turn_off_blocking_entity"
 CONF_TURN_OFF_BLOCKING_ENTITIES = "turn_off_blocking_entities"
+CONF_BLOCKED_TIMEOUT = "blocking_entities_timeout"
 
 STATES = ['idle', 'blocked',
           {'name': 'active', 'children': ['control'],


### PR DESCRIPTION
## Summary
- add a new `blocking_entities_timeout` option so each controller can define how long manual overrides keep the automation blocked
- start and manage a dedicated timer while the controller is blocked to turn the lights off once motion has been absent for the configured timeout
- keep the blocking timer in sync with motion and blocking booleans so the automation returns to automatic control once manual lights are cleared

## Testing
- python -m compileall custom_components/room_light_control

------
https://chatgpt.com/codex/tasks/task_b_68cfb1b739948327a5813d581ec25bd9